### PR TITLE
Fix tooltip transition

### DIFF
--- a/styles/tooltips.less
+++ b/styles/tooltips.less
@@ -30,8 +30,7 @@
 
   &.in {
     opacity: 1;
-    transition-timing-function: ease-out;
-    transition-duration: .1s;
+    transition: opacity .1s ease-out;
   }
 
   &.top .tooltip-arrow {


### PR DESCRIPTION
This PR only transitions the `opacity` property. I think currently it defaults to `all` and therefore also transitions `top` and `left`. Should fix this: https://discuss.atom.io/t/isotope-ui-disable-tooltip-animation/15072 He mentions animations in general, but I'm pretty sure he means the "movement".

Sorry, that got carried over from One and I fixed it only after you forked. :innocent:
