### PR TITLE
Limit iteration count of <progress> elements

### DIFF
--- a/styles/progress.less
+++ b/styles/progress.less
@@ -43,7 +43,7 @@ progress {
       z-index: 1;
       background: radial-gradient(circle, @ui-accent, mix(@ui-accent, #fff, 50%));
       transform: translate(0);
-      -webkit-animation: animate 3s alternate ease-in-out infinite;
+      -webkit-animation: animate 3s alternate ease-in-out 7; // stop animation after 7 runs (21s) to limit CPU usage
     }
   }
 }


### PR DESCRIPTION
The animation of the `<progress>` element can make the CPU spike a bit, this PR:
- Limits the buffering animation to only 21s
