### PR TITLE
Add text-color-modified

### DIFF
--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -110,6 +110,7 @@
 @text-color-success: @fg-success;
 @text-color-warning: @fg-warning;
 @text-color-error:   @fg-error;
+@text-color-modified: @fg-warning;
 
 @background-color-info: @bg-info;
 @background-color-success: @bg-success;


### PR DESCRIPTION
We might want to set this to something else. I took the "copy color from warning" idea from [one-dark-ui](https://github.com/atom/one-dark-ui/blob/master/styles/ui-variables.less#L151)
