### PR TITLE
Fix deprecated (since Atom v1.13.0) selectors.

### DIFF
--- a/styles/editor-mini.less
+++ b/styles/editor-mini.less
@@ -10,8 +10,7 @@ atom-text-editor.mini {
   max-height: ~"calc("@component-line-height ~"+ 2px)";
   height: ~"calc("@component-line-height ~"+ 2px)";
 
-  &,
-  &::shadow {
+  & {
     background: @level-3-bg;
     color: @base-fg;
 
@@ -29,8 +28,7 @@ atom-text-editor.mini {
     }
   }
 
-  &.is-focused,
-  &.is-focused::shadow {
+  &.is-focused {
     background: @input-background-color;
     box-shadow: 0 0 0 1px @ui-accent;
     color: @fg-highlight;

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,5 +1,4 @@
-atom-text-editor,
-atom-text-editor::shadow {
+atom-text-editor {
   .ui-site-1 {
     background: @ui-site-color-1;
     .text-subtle {


### PR DESCRIPTION
Remove selectors that have been deprecated since Atom v1.13.0. Fixes #55.