### PR TITLE
Update the default system font stack

### DIFF
--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -2,7 +2,7 @@
 
 
 //provide defaults, users can set configs that are handled in config.less
-@font-family: '.SFNSText-Regular', 'SF UI Text', 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;
+@font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 @font-size: 11px;
 @font-weight: 400;
 


### PR DESCRIPTION
I found that the default system font stack wasn't working well for me on macOS Sierra. It would end up displaying Lucida Grande when it should have been San Francisco. After a little research I thought I'd update the stack to match the one used by GitHub.